### PR TITLE
Adds LetterOfCreditV2 contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Note: you will need to set the `PRIVATE_KEY` environment variable (and also the 
 | CollateralVault                   | [0x5d2725fdE4d7Aa3388DA4519ac0449Cc031d675f](https://etherscan.io/address/0x5d2725fdE4d7Aa3388DA4519ac0449Cc031d675f)   |
 | LetterOfCredit Proxy              | [0x14db9a91933aD9433E1A0dB04D08e5D9EF7c4808](https://etherscan.io/address/0x14db9a91933aD9433E1A0dB04D08e5D9EF7c4808)   |
 | LetterOfCredit Proxy Admin        | [0x12225bB169b38EF8849DD4F5Cc466ae5996e341D](https://etherscan.io/address/0x12225bB169b38EF8849DD4F5Cc466ae5996e341D)   |
-| LetterOfCredit Singleton          | [0x750Ab78B4fe51292d1F0053845AACe3eA959D5AD](https://etherscan.io/address/0x750Ab78B4fe51292d1F0053845AACe3eA959D5AD)   |
+| LetterOfCredit Singleton          | [0x24573B112456d3a96c97fB460B436e8CA870e27E](https://etherscan.io/address/0x24573B112456d3a96c97fB460B436e8CA870e27E)   |
+| PassThroughLiquidator             | [0x9ae1CAA5cE6fA330fcE98315159BCD433B1342b8](https://etherscan.io/address/0x9ae1CAA5cE6fA330fcE98315159BCD433B1342b8)   |
 | PythPriceOracle                   | [0xC6f3405c861Fa0dca04EC4BA59Bc189D1d56Ee05](https://etherscan.io/address/0xC6f3405c861Fa0dca04EC4BA59Bc189D1d56Ee05)   |
 | Reward                            | [0xC6a06f2D000b8CFDd392C4d6AB715a9ff1dA22dA](https://etherscan.io/address/0xC6a06f2D000b8CFDd392C4d6AB715a9ff1dA22dA)   |
 | TimeBasedCollateralPool Singleton | [0xCc437a7Bb14f07de09B0F4438df007c8F64Cf29f](https://etherscan.io/address/0xCc437a7Bb14f07de09B0F4438df007c8F64Cf29f)   |
@@ -117,6 +118,11 @@ This contract’s token support is configured with ERC-20 tokens that must also 
 `CollateralVault.sol` and `PythPriceOracle.sol` as well as their respective maximum usage 
 limits. Note: `LetterofCredit` is deployed as a proxy that delegates to a singleton contract.
 
+### PassThroughLiquidator.sol
+A flexible liquidator that allows calldata a target to be configured off-chain and passed through the LetterOfCredit
+contract to accomplish liquidation. This allows more complex liquidation strategies and the use of many different protocols
+generically. See the contract details for information on how to encode the pass-through data that configures liquidation.
+
 ### Pricing.sol
 A contract of math-related helpers to support `CollateralVault.sol`, `PythPriceOracle.sol`, and 
 `TimeBasedCollateralPool.sol`in pricing calculations.
@@ -162,7 +168,7 @@ lightweight via separating state storage (in the proxy contract) from core logic
 A simple liquidator that may be configured and used to convert at-risk LOCs. There are much more efficient and 
 profit-maximizing liquidators that can and hopefully will be written by 3rd party liquidators, but it is in Anvil's 
 best interest to have many functioning liquidators that guarantee that at-risk LOCs are converted, so Anvil has
-provided an implementation that others may use. 
+provided an implementation using UniswapV2 liquidity that others may use.
 
 ### VisibileBeaconProxy.sol
 Extends OpenZeppelin’s [BeaconProxy](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/proxy/beacon/BeaconProxy.sol) 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Note: you will need to set the `PRIVATE_KEY` environment variable (and also the 
 | LetterOfCredit Proxy Admin        | [0x12225bB169b38EF8849DD4F5Cc466ae5996e341D](https://etherscan.io/address/0x12225bB169b38EF8849DD4F5Cc466ae5996e341D)   |
 | LetterOfCredit Singleton          | [0x24573B112456d3a96c97fB460B436e8CA870e27E](https://etherscan.io/address/0x24573B112456d3a96c97fB460B436e8CA870e27E)   |
 | PassThroughLiquidator             | [0x9ae1CAA5cE6fA330fcE98315159BCD433B1342b8](https://etherscan.io/address/0x9ae1CAA5cE6fA330fcE98315159BCD433B1342b8)   |
+| Permit2PassThroughLiquidator      | [0x8Aa57e442e4562c80FDDAD1b71ADF0BA75E2eb4C](https://etherscan.io/address/0x8Aa57e442e4562c80FDDAD1b71ADF0BA75E2eb4C)   |
 | PythPriceOracle                   | [0xC6f3405c861Fa0dca04EC4BA59Bc189D1d56Ee05](https://etherscan.io/address/0xC6f3405c861Fa0dca04EC4BA59Bc189D1d56Ee05)   |
 | Reward                            | [0xC6a06f2D000b8CFDd392C4d6AB715a9ff1dA22dA](https://etherscan.io/address/0xC6a06f2D000b8CFDd392C4d6AB715a9ff1dA22dA)   |
 | TimeBasedCollateralPool Singleton | [0xCc437a7Bb14f07de09B0F4438df007c8F64Cf29f](https://etherscan.io/address/0xCc437a7Bb14f07de09B0F4438df007c8F64Cf29f)   |
@@ -122,6 +123,13 @@ limits. Note: `LetterofCredit` is deployed as a proxy that delegates to a single
 A flexible liquidator that allows calldata a target to be configured off-chain and passed through the LetterOfCredit
 contract to accomplish liquidation. This allows more complex liquidation strategies and the use of many different protocols
 generically. See the contract details for information on how to encode the pass-through data that configures liquidation.
+
+### Permit2PassThroughLiquidator.sol
+A flexible liquidator that allows calldata a target to be configured off-chain and passed through the LetterOfCredit
+contract to accomplish liquidation. This allows more complex liquidation strategies and the use of many different protocols
+generically. See the contract details for information on how to encode the pass-through data that configures liquidation.
+The difference between this contract and `PassThroughLiquidator` is that this contract assumes that the target contract 
+uses the Permit2 contract to manage approvals rather than ERC-20.
 
 ### Pricing.sol
 A contract of math-related helpers to support `CollateralVault.sol`, `PythPriceOracle.sol`, and 

--- a/contracts/LetterOfCreditStorage.sol
+++ b/contracts/LetterOfCreditStorage.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: ISC
+pragma solidity 0.8.25;
+
+import "./interfaces/ICollateral.sol";
+import "./interfaces/ILetterOfCredit.sol";
+
+/**
+ * @title Contract specifying all ordered storage used by the existing LetterOfCredit contract proxy to avoid upgrade
+ * storage collisions. All upgrade target candidates must inherit from this contract before any others.
+ *
+ * @dev These state variables were pulled verbatim from first LetterOfCredit contract pointed at by Anvil's
+ * LetterOfCredit proxy.
+ */
+abstract contract LetterOfCreditStorage {
+    /***********
+     * STORAGE *
+     ***********/
+
+    /// NB: uint96 stores up to 7.9 x 10^28 and packs tightly with addresses (12 + 20 = 32 bytes).
+    uint96 internal locNonce;
+
+    /// Max age of oracle update.
+    /// NB: uint16 gets us up to ~18hrs, which should be plenty. If our oracle is that stale we have very large problems.
+    uint16 public maxPriceUpdateSecondsAgo;
+
+    /// Extending a LOC can make it so that the total duration of any given LOC may be larger than this, but no LOC may
+    /// have more than this number of seconds remaining.
+    uint32 public maxLocDurationSeconds;
+
+    /// The ICollateral contract to use for new LOCs, after which, it is stored on the LOC referenced.
+    ICollateral public collateralContract;
+    // The IPriceOracle to use for all price interactions (NB: for both new and existing LOCs).
+    IPriceOracle public priceOracle;
+
+    /// id (nonce) => Letter of Credit
+    mapping(uint96 id => LOC letterOfCredit) internal locs;
+
+    /// Credited Token Address => token available for use as LOC credited tokens and its limits for use.
+    mapping(address creditedTokenAddress => CreditedToken creditedToken) internal creditedTokens;
+
+    /// collateral token address => credited token address => CollateralFactor.
+    mapping(address collateralTokenAddress => mapping(address creditedTokenAddress => CollateralFactor collateralFactor))
+        internal collateralToCreditedToCollateralFactors;
+
+    /*******************
+     * STORAGE STRUCTS *
+     *******************/
+
+    struct CreditedToken {
+        uint256 minPerDynamicLOC;
+        uint256 maxPerDynamicLOC;
+        uint256 globalMaxInDynamicUse;
+        uint256 globalAmountInDynamicUse;
+    }
+
+    struct CollateralFactor {
+        uint16 creationCollateralFactorBasisPoints;
+        uint16 collateralFactorBasisPoints;
+        uint16 liquidatorIncentiveBasisPoints;
+    }
+
+    struct LOC {
+        uint96 collateralId;
+        address creator;
+        // --- storage slot separator
+        address beneficiary;
+        // NB: uint32 gets us to the year 2106. If we hit that, redeploy.
+        uint32 expirationTimestamp;
+        uint16 collateralFactorBasisPoints;
+        uint16 liquidatorIncentiveBasisPoints;
+        // --- storage slot separator
+        ICollateral collateralContract;
+        address collateralTokenAddress;
+        uint256 collateralTokenAmount;
+        uint256 claimableCollateral;
+        address creditedTokenAddress;
+        uint256 creditedTokenAmount;
+    }
+}

--- a/contracts/PassThroughLiquidator.sol
+++ b/contracts/PassThroughLiquidator.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: ISC
+pragma solidity 0.8.25;
+
+import "./interfaces/ILiquidator.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @notice ILiquidator implementation that liquidates by determining the contract to call as well as
+ * the data to call it with from calldata. This is meant to be generic, allowing liquidation logic
+ * to change without redeploying.
+ */
+contract PassThroughLiquidator is ILiquidator, Ownable2Step {
+    using SafeERC20 for IERC20;
+
+    // NB: Immutable to save gas. If, for some reason, this needs to change, redeploy.
+    address private immutable authorizedCaller;
+
+    error Unauthorized();
+
+    constructor(address _owner, address _authorizedCaller) Ownable(_owner) {
+        authorizedCaller = _authorizedCaller;
+    }
+
+    /**
+     * Encodes the provided data so that it may be passed as the last argument of liquidate(...).
+     * @param _addressToApprove The address that will be ERC-20 approved to transfer assets being liquidated.
+     * @param _targetContract The contract to be called with `_data` to accomplish the liquidation.
+     * @param _data The data being passed to `_targetContract` to accomplish the liquidation.
+     * @return The encoded bytes.
+     */
+    function encodeParameters(
+        address _addressToApprove,
+        address _targetContract,
+        bytes memory _data
+    ) external pure returns (bytes memory) {
+        return abi.encode(_addressToApprove, _targetContract, _data);
+    }
+
+    /**
+     * Liquidates via the contract and data provided in the last parameter (`_liquidationParams`).
+     * It is assumed that this contract call will result in the required output token amount being sent to
+     * the `authorizedCaller`, though it is up to the `authorizedCaller` to verify that.
+     * @dev Note: _liquidatorParams must be encoded in the format outlined by `encodeParameters(...)` above.
+     *
+     * @inheritdoc ILiquidator
+     */
+    function liquidate(
+        address,
+        address _inputTokenAddress,
+        uint256 _maxInputTokenAmount,
+        address,
+        uint256,
+        bytes calldata // _liquidatorParams
+    ) external {
+        if (msg.sender != authorizedCaller) revert Unauthorized();
+
+        {
+            IERC20 inputToken = IERC20(_inputTokenAddress);
+
+            // The next two calls may return `false` on failure. Instead of asserting `true`, we'll save gas in the
+            // happy path at the expense of gas in the failure path, which will revert in the swap below.
+
+            /*** Obtain collateral tokens from msg.sender ***/
+            // NB: This will fail without sufficient allowance provided by msg.sender
+            inputToken.safeTransferFrom(msg.sender, address(this), _maxInputTokenAmount);
+
+            address addressToApprove;
+            assembly ("memory-safe") {
+                // Calldata words 0-5 (ignoring method ID) are the parameters
+                // [skipped] word 6 is the length of the _liquidatorParams bytes, but we know the structure of it so we can ignore it
+                // word 7: 7*32 + 4 for method ID = 228 — this is the addressToApprove
+                addressToApprove := calldataload(228)
+            }
+
+            // NB: Allowance will likely remain. If we're comfortable with it all being transferred right now,
+            // we are comfortable with less being transferred and some approval amount remaining.
+            inputToken.forceApprove(addressToApprove, _maxInputTokenAmount);
+        }
+
+        assembly ("memory-safe") {
+            // word 8: 8*32 + 4 = 260 for method ID — this is the targetContract
+            let targetContract := calldataload(260)
+            // [skipped] word 9 of calldata is the byte index in the _liquidationParams where the encoded "data" starts (we know that is 96)
+
+            // Set targetCalldata equal to the free memory pointer location. NB: we are not "allocating" memory.
+            // We're just using unallocated memory as scratch space since we know that nothing will overwrite it while we use it.
+            let targetCalldata := mload(0x40)
+            // word 10: 10*32 + 4 for method ID = 324 — this is the size of the "data" array from _liquidatorParams
+            let targetCalldataSize := calldataload(324)
+            // word 11: 11*32 + 4 for method ID = 356 — this is the start byte of the bytes that make up "data"
+            calldatacopy(targetCalldata, 356, targetCalldataSize) // populate data for the call below
+
+            // call the targetContract with the provided data to execute the liquidation.
+            let ok := call(gas(), targetContract, 0, targetCalldata, targetCalldataSize, 0, 0)
+            if iszero(ok) {
+                // NB: Just reuse the targetCalldata pointer since it's done being used.
+                returndatacopy(targetCalldata, 0, returndatasize())
+                revert(targetCalldata, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @notice Transfers the entire balance of the specified token to the owner.
+     * @dev Note that only the owner address may call this function.
+     * @param _tokens The tokens to transfer to the owner.
+     */
+    function retrieveTokens(IERC20[] calldata _tokens) external onlyOwner {
+        for (uint256 i = 0; i < _tokens.length; ++i) {
+            uint256 balance = IERC20(_tokens[i]).balanceOf(address(this));
+            if (balance > 0) {
+                IERC20(_tokens[i]).safeTransfer(owner(), balance);
+            }
+        }
+    }
+}

--- a/contracts/Permit2PassThroughLiquidator.sol
+++ b/contracts/Permit2PassThroughLiquidator.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: ISC
+pragma solidity 0.8.25;
+
+import "./interfaces/ILiquidator.sol";
+import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * Interface that represents the single function of the Permit2 contract that Permit2PassThroughLiquidator calls.
+ */
+interface IPermit2 {
+    function approve(address token, address spender, uint160 amount, uint48 expiration) external;
+}
+
+/**
+ * @notice ILiquidator implementation that liquidates by determining the contract to call as well as
+ * the data to call it with from calldata. This is meant to be generic, allowing liquidation logic
+ * to change without redeploying.
+ * @dev This contract assumes that the target contract requires Permit2 approvals rather than ERC-20 approvals.
+ */
+contract Permit2PassThroughLiquidator is ILiquidator, Ownable2Step {
+    using SafeERC20 for IERC20;
+
+    // NB: Immutable to save gas. If, for some reason, this needs to change, redeploy.
+    address private immutable authorizedCaller;
+    address private immutable permit2Address;
+
+    error Unauthorized();
+
+    constructor(address _owner, address _authorizedCaller, address _permit2Address) Ownable(_owner) {
+        authorizedCaller = _authorizedCaller;
+        permit2Address = _permit2Address;
+    }
+
+    /**
+     * Encodes the provided data so that it may be passed as the last argument of liquidate(...).
+     * @param _addressToApprove The address that will be approved within the Permit2 contract to transfer the assets being liquidated.
+     * @param _targetContract The contract to be called with `_data` to accomplish the liquidation.
+     * @param _data The data being passed to `_targetContract` to accomplish the liquidation.
+     * @return The encoded bytes.
+     */
+    function encodeParameters(
+        address _addressToApprove,
+        address _targetContract,
+        bytes memory _data
+    ) external pure returns (bytes memory) {
+        return abi.encode(_addressToApprove, _targetContract, _data);
+    }
+
+    /**
+     * Liquidates via the contract and data provided in the last parameter (`_liquidationParams`).
+     * It is assumed that this contract call will result in the required output token amount being sent to
+     * the `authorizedCaller`, though it is up to the `authorizedCaller` to verify that.
+     * @dev Note: _liquidatorParams must be encoded in the format outlined by `encodeParameters(...)` above.
+     * @dev Note: approvePermit2(...) must have been called for the `_inputTokenAddress` in question prior to this call.
+     *
+     * @inheritdoc ILiquidator
+     */
+    function liquidate(
+        address,
+        address _inputTokenAddress,
+        uint256 _maxInputTokenAmount,
+        address,
+        uint256,
+        bytes calldata // _liquidatorParams
+    ) external {
+        if (msg.sender != authorizedCaller) revert Unauthorized();
+
+        {
+            IERC20 inputToken = IERC20(_inputTokenAddress);
+
+            // The next two calls may return `false` on failure. Instead of asserting `true`, we'll save gas in the
+            // happy path at the expense of gas in the failure path, which will revert in the swap below.
+
+            /*** Obtain collateral tokens from msg.sender ***/
+            // NB: This will fail without sufficient allowance provided by msg.sender.
+            inputToken.safeTransferFrom(msg.sender, address(this), _maxInputTokenAmount);
+
+            address addressToApprove;
+            assembly ("memory-safe") {
+                // Calldata words 0-5 (ignoring method ID) are the parameters.
+                // [skipped] word 6 is the length of the _liquidatorParams bytes, but we know the structure of it so we can ignore it.
+                // word 7: 7*32 + 4 for method ID = 228 — this is the addressToApprove.
+                addressToApprove := calldataload(228)
+            }
+
+            // NB: 0 expiration means the allowance only lasts the duration of the block.
+            IPermit2(permit2Address).approve(_inputTokenAddress, addressToApprove, uint160(_maxInputTokenAmount), 0);
+        }
+
+        assembly ("memory-safe") {
+            // word 8: 8*32 + 4 = 260 for method ID — this is the targetContract.
+            let targetContract := calldataload(260)
+            // [skipped] word 9 of calldata is the byte index in the _liquidationParams where the encoded "data" starts (we know that is 96).
+
+            // Set targetCalldata equal to the free memory pointer location. NB: we are not "allocating" memory.
+            // We're just using unallocated memory as scratch space since we know that nothing will overwrite it while we use it.
+            let targetCalldata := mload(0x40)
+            // word 10: 10*32 + 4 for method ID = 324 — this is the size of the "data" array from _liquidatorParams.
+            let targetCalldataSize := calldataload(324)
+            // word 11: 11*32 + 4 for method ID = 356 — this is the start byte of the bytes that make up "data".
+            calldatacopy(targetCalldata, 356, targetCalldataSize) // populate data for the call below.
+
+            // call the targetContract with the provided data to execute the liquidation.
+            let ok := call(gas(), targetContract, 0, targetCalldata, targetCalldataSize, 0, 0)
+            if iszero(ok) {
+                // NB: Just reuse the targetCalldata pointer since it's done being used.
+                returndatacopy(targetCalldata, 0, returndatasize())
+                revert(targetCalldata, returndatasize())
+            }
+        }
+    }
+
+    /**
+     * @notice Approves the Permit2 contract to spend the maximum amount of the provided tokens on behalf of this
+     * contract.
+     * @dev This is intentionally not protected by onlyOwner or some other auth check.
+     * Note: this must be called for a token prior to using it as the _inputTokenAddress in the liquidate(...) function.
+     * @param _tokens The tokens to approve the Permit2 contract to spend.
+     */
+    function approvePermit2(IERC20[] calldata _tokens) external {
+        for (uint256 i = 0; i < _tokens.length; ++i) {
+            _tokens[i].forceApprove(permit2Address, type(uint160).max);
+        }
+    }
+
+    /**
+     * @notice Transfers the entire balance of the specified token to the owner.
+     * @dev Note that only the owner address may call this function.
+     * @param _tokens The tokens to transfer to the owner.
+     */
+    function retrieveTokens(IERC20[] calldata _tokens) external onlyOwner {
+        for (uint256 i = 0; i < _tokens.length; ++i) {
+            uint256 balance = IERC20(_tokens[i]).balanceOf(address(this));
+            if (balance > 0) {
+                IERC20(_tokens[i]).safeTransfer(owner(), balance);
+            }
+        }
+    }
+}

--- a/contracts/UniswapLiquidator.sol
+++ b/contracts/UniswapLiquidator.sol
@@ -39,13 +39,15 @@ contract UniswapLiquidator is ILiquidator, Ownable2Step {
      * @param _maxInputTokenAmount The maximum amount of the input token the liquidator may transfer from the caller.
      * @param _outputTokenAddress The address of the token the caller will receive as a result of this call.
      * @param _exactOutputTokenAmount The exact amount of the token the caller will receive as a result of this call.
+     * @param [unused].
      */
     function liquidate(
         address _initiator,
         address _inputTokenAddress,
         uint256 _maxInputTokenAmount,
         address _outputTokenAddress,
-        uint256 _exactOutputTokenAmount
+        uint256 _exactOutputTokenAmount,
+        bytes calldata
     ) external {
         IERC20 inputToken = IERC20(_inputTokenAddress);
 

--- a/contracts/interfaces/ILetterOfCredit.sol
+++ b/contracts/interfaces/ILetterOfCredit.sol
@@ -48,6 +48,27 @@ interface ILetterOfCredit {
      * EVENTS *
      **********/
 
+    event LOCCreatedV2(
+        address indexed creator,
+        address indexed beneficiary,
+        bytes32 indexed tag,
+        address collateralContractAddress,
+        address collateralTokenAddress,
+        uint256 collateralTokenAmount,
+        uint256 claimableCollateral,
+        uint32 expirationTimestamp,
+        uint16 collateralFactorBasisPoints,
+        uint16 liquidatorIncentiveBasisPoints,
+        address creditedTokenAddress,
+        uint256 creditedTokenAmount,
+        uint96 id,
+        uint96 collateralId
+    );
+
+    /**
+     * Deprecated. Some of these events were emitted prior to the proxy upgrade that moved to using LOCCreatedV2, so
+     * this event must exist for backward compatibility.
+     */
     event LOCCreated(
         address indexed creator,
         address indexed beneficiary,

--- a/contracts/interfaces/ILiquidatable.sol
+++ b/contracts/interfaces/ILiquidatable.sol
@@ -14,11 +14,13 @@ interface ILiquidatable {
      * @param _oraclePriceUpdate (optional) The oracle price update to be used for this liquidation.
      * @param _creatorAuthorization (optional) If not called by the creator, and the LOC is healthy, the signed creator
      * authorization necessary to convert the LOC.
+     * @param _liquidatorParams (optional) Parameters to be parsed and used by the ILiquidator implementation contract.
      */
     function convertLOC(
         uint96 _locId,
         address _iLiquidatorToUse,
         bytes calldata _oraclePriceUpdate,
-        bytes calldata _creatorAuthorization
+        bytes calldata _creatorAuthorization,
+        bytes calldata _liquidatorParams
     ) external payable;
 }

--- a/contracts/interfaces/ILiquidator.sol
+++ b/contracts/interfaces/ILiquidator.sol
@@ -11,12 +11,14 @@ interface ILiquidator {
      * @param _inputTokenAmount The amount of the token the liquidator will receive from the caller.
      * @param _outputTokenAddress The address of the token the caller will receive as a result of this call.
      * @param _outputTokenAmount The amount of the token the caller will receive as a result of this call.
+     * @param _liquidatorParams Parameters, if any, to be parsed and used by the ILiquidator implementation contract.
      */
     function liquidate(
         address _initiator,
         address _inputTokenAddress,
         uint256 _inputTokenAmount,
         address _outputTokenAddress,
-        uint256 _outputTokenAmount
+        uint256 _outputTokenAmount,
+        bytes calldata _liquidatorParams
     ) external;
 }

--- a/contracts/test/MockLiquidator.sol
+++ b/contracts/test/MockLiquidator.sol
@@ -19,7 +19,8 @@ contract MockLiquidator is ILiquidator {
         address _inputTokenAddress,
         uint256 _inputTokenAmount,
         address _outputTokenAddress,
-        uint256 _outputTokenAmount
+        uint256 _outputTokenAmount,
+        bytes calldata /* not used */
     ) external {
         require(_inputTokenAmount > 0 && _outputTokenAmount > 0, "invalid input and/or output amount");
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,14 +10,19 @@ import { defineProxyTasks } from './tasks/proxy'
 
 // NB: Will need to set this to interact with non-localhost environments.
 const { PROVIDER_URL } = process.env
+// If compiling LetterOfCredit contract
+const optimizerRuns = 833
+// If not compiling LetterOfCredit contract
+// const optimizerRuns = 999999
 
 const config: HardhatUserConfig = {
   solidity: {
     version: '0.8.25',
     settings: {
+      viaIR: true,
       optimizer: {
         enabled: true,
-        runs: 150
+        runs: optimizerRuns
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anvil-contracts",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Solidity smart contracts for the Anvil protocol",
   "files": [
     "/contracts/**/*.sol"

--- a/test/LetterOfCredit/createDynamicLOC.ts
+++ b/test/LetterOfCredit/createDynamicLOC.ts
@@ -51,20 +51,19 @@ describe('LetterOfCredit', function () {
       await vault.getAddress()
     )
 
-    const tx = await letterOfCredit
-      .connect(creator)
-      .createDynamicLOC(
-        await beneficiary.getAddress(),
-        await collateralToken.getAddress(),
-        collateralTokenAmount,
-        await creditedToken.getAddress(),
-        creditedTokenAmount,
-        expirationSeconds,
-        ethers.AbiCoder.defaultAbiCoder().encode(['uint256', 'int32'], [outputPerUnitInputTokenPrice, exponent]),
-        allowanceSignature
-      )
+    const tx = await letterOfCredit.connect(creator).createDynamicLOC(
+      await beneficiary.getAddress(),
+      await collateralToken.getAddress(),
+      collateralTokenAmount,
+      await creditedToken.getAddress(),
+      creditedTokenAmount,
+      expirationSeconds,
+      ethers.AbiCoder.defaultAbiCoder().encode(['uint256', 'int32'], [outputPerUnitInputTokenPrice, exponent]),
+      allowanceSignature,
+      `0x${'af'.repeat(32)}` // tag
+    )
 
-    const ev: any = await getEmittedEventArgs(tx, letterOfCredit, 'LOCCreated')
+    const ev: any = await getEmittedEventArgs(tx, letterOfCredit, 'LOCCreatedV2')
     expect(ev.creator).to.equal(await creator.getAddress(), 'creator address mismatch')
     expect(ev.beneficiary).to.equal(await beneficiary.getAddress(), 'beneficiary address mismatch')
     expect(ev.collateralTokenAddress).to.equal(await collateralToken.getAddress(), 'collateral address mismatch')

--- a/test/LetterOfCredit/createStaticLOC.ts
+++ b/test/LetterOfCredit/createStaticLOC.ts
@@ -35,17 +35,16 @@ describe('LetterOfCredit', function () {
       await vault.getAddress()
     )
 
-    const tx = await letterOfCredit
-      .connect(creator)
-      .createStaticLOC(
-        await beneficiary.getAddress(),
-        await creditedToken.getAddress(),
-        creditedTokenAmount,
-        expirationSeconds,
-        allowanceSignature
-      )
+    const tx = await letterOfCredit.connect(creator).createStaticLOC(
+      await beneficiary.getAddress(),
+      await creditedToken.getAddress(),
+      creditedTokenAmount,
+      expirationSeconds,
+      allowanceSignature,
+      `0x${'af'.repeat(32)}` // tag
+    )
 
-    const ev: any = await getEmittedEventArgs(tx, letterOfCredit, 'LOCCreated')
+    const ev: any = await getEmittedEventArgs(tx, letterOfCredit, 'LOCCreatedV2')
     expect(ev.creator).to.equal(await creator.getAddress(), 'creator address mismatch')
     expect(ev.beneficiary).to.equal(await beneficiary.getAddress(), 'beneficiary address mismatch')
     expect(ev.collateralTokenAddress).to.equal(await creditedToken.getAddress(), 'collateral address mismatch')


### PR DESCRIPTION
Note: name is still LetterOfCredit. Version is denoted in contract header documentation.

Also:
* Adds _tag parameter to createStaticLOC and createDynamicLOC allowing the LOC creator to specify some identifier that is valuable to the creator and/or the beneficiary for off-chain association
* Updates the ILiquidator interface and implementations to support an opaque bytes parameter to be parsed and used by the implementation in order to better configure liquidation
* Adds a PassThroughLiquidator that may be used to generically liqudiated via various sources of liquidity by configuring newly added liquidation parameter appropriately
* Deprecates LOCCreated event and adds LOCCreatedV2 to emit new _tag parameter as well as the assocaited collateral ID.
* Adds viaIR solc compiler option to avoid stack-too-deep errors in LetterOfCredit contract
* Bumps the version of the contracts to v2.0.0 since this represents a breaking change to the LetterOfCredit and ILiquidator APIs