### PR TITLE
[N-03] EIP-712 Version Consistency in New ANVL Token Deployment

### DIFF
--- a/contracts/governance/Anvil.sol
+++ b/contracts/governance/Anvil.sol
@@ -9,11 +9,12 @@ import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
  * @title Anvil Token
  * @notice Anvil governance token, using OZ ERC20Votes.
  *
+ * @dev Contract Version: 2.0.0
  * @custom:security-contact security@af.xyz
  */
 contract Anvil is ERC20Votes {
     /**
-     * @notice Deploys the Anvil token, allocating the provided amount of tokens to the deployer.
+     * @notice Deploys the Anvil token, allocating the total supply of tokens to the provided destination.
      *
      * @param destinationAddress The address to which the tokens will be minted.
      */

--- a/contracts/governance/AnvilGovernorDelegate.sol
+++ b/contracts/governance/AnvilGovernorDelegate.sol
@@ -17,6 +17,7 @@ import {IVotes} from "@openzeppelin/contracts/governance/utils/IVotes.sol";
  * @title This is version 2 of the Governor contract that is delegated to by `AnvilGovernorDelegator` for the Anvil
  * protocol to implement governance logic.
  *
+ * @dev Contract Version: 2.0.0
  * @custom:security-contact security@af.xyz
  */
 contract AnvilGovernorDelegate is
@@ -95,6 +96,14 @@ contract AnvilGovernorDelegate is
      * Initializes this delegate so that it may be used, as it operates within the UpgradableProxy pattern, in which
      * logic that would typically be contained within a constructor is moved to `initialize(...)` since the delegate
      * must be deployed before it is used by the contract that delegates to it.
+     *
+     * @dev This function has already been called and cannot be called again.
+     *
+     * @param timelock_ The address of the TimelockController contract.
+     * @param governanceToken_ The address of the governance token.
+     * @param votingPeriod_ The voting period for proposals.
+     * @param votingDelay_ The voting delay for proposals.
+     * @param proposalThreshold_ The voting threshold to create a proposal.
      */
     function initialize(
         TimelockControllerUpgradeable timelock_,


### PR DESCRIPTION
Audit Feedback:
>Consider updating the EIP-712 version field in the newly deployed ANVL token to explicitly
indicate the new release and avoid ambiguity in off-chain integrations.

This work updates the EIP712 version field to 2.